### PR TITLE
fix misspelled `options`

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ let settings
 chrome.storage.sync.get(['disable'], function (options) {
     if (typeof options.disable === 'undefined') {
         chrome.storage.sync.set({disable: false})
-        oprions.disable = false
+        options.disable = false
         disable = false
     } else
         disable = options.disable


### PR DESCRIPTION
I believe this was spelled wrong. No longer. 😊😊😊😊😊😊😊😊😊